### PR TITLE
flopimg.cpp: Fix seg fault on bad tbuf

### DIFF
--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -2261,7 +2261,7 @@ std::vector<bool> floppy_image_format_t::generate_bitstream_from_track(int track
 {
 	std::vector<bool> trackbuf;
 	std::vector<uint32_t> &tbuf = image->get_buffer(track, head, subtrack);
-	if(tbuf.size() <= 1) {
+	if((int)tbuf.size() <= 1) {
 		// Unformatted track
 		int track_size = 200000000/cell_size;
 		trackbuf.resize(track_size, false);


### PR DESCRIPTION
With assertions disabled (all builds without DEBUG defined?) calling image->get_buffer, line 2263, with bad track or head values yields a broken tbuf.
Without the int cast the signed result of tbuf.size() lets the broken tbuf pass, generating a seg fault when indexed at line 2290.
The issue fixed by #1 triggers this behavior.